### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Feedstock Maintainers
 
 * [@LucaMarconato](https://github.com/LucaMarconato/)
 * [@giovp](https://github.com/giovp/)
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 * [@melonora](https://github.com/melonora/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,6 @@ about:
 extra:
   recipe-maintainers:
     - giovp
-    - goanpeca
     - jaimergp
     - LucaMarconato
     - melonora


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #22